### PR TITLE
Add missing drivelist native package to executable

### DIFF
--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -45,6 +45,8 @@ runs:
           rm -Recurse -Force ${env:LOCALAPPDATA}\node-gyp\Cache
           npm install
         }
+        # workaround exclusion of drivelist compiled module
+        rm node_modules\pkg\dictionary\drivelist.js
         npm run build
         npm run pkg
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "migrator",
-      "version": "0.0.3",
+      "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@oclif/core": "^2",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   "pkg": {
     "scripts": "dist/*.js",
     "assets": [
+      "node_modules/drivelist/build/Release/drivelist.node",
       "node_modules/lzma-native/prebuilds/**/*",
       "node_modules/usb/prebuilds/**/*"
     ]


### PR DESCRIPTION
Must remove [drivelist.js](https://github.com/vercel/pkg/blob/main/dictionary/drivelist.js) from pkg package so it will accept the built `drivelist.node` module.