### PR TITLE
Add image flag and minor improvements to non-interactive flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,13 @@ You need a balenaOS image for your device type. See the downloads [page](https:/
 ### Migrator
 The command below prepares the migration, and then reboots to execute it and launch balenaOS.
 ```
-  migrator -i <value> [--noninteractive]
+  migrator -i <value> [-y]
 
 FLAGS
-  -i, --image=<value>  (required) balenaOS flasher image path name
-  --noninteractive     no user input; use defaults
+  -i, --image=<value>    (required) balenaOS flasher image path name
+  -y, --non-interactive  no user input; use defaults
 ```
-Since the migrator executes a destructive operation, it first prompts you to confirm continuing. Use the `--non-interactive` option to avoid the prompt and immediately begin the migration.
+Since the migrator executes a destructive operation, it first prompts you to confirm. Use the `--non-interactive` option to avoid the prompt and begin the migration immediately.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -29,14 +29,18 @@ These commands generate a single-file executable `migrator.exe` in the `dist` di
 You need a balenaOS image for your device type. See the downloads [page](https://www.balena.io/os) to retrieve the `<flasher-image-archive>` file. Run the commands below to configure the image. See the balenaCLI [documentation](https://docs.balena.io/reference/balena-cli/#os-configure-image) for details of the `os configure` command.
 
 ```
-> unzip <flasher-image-archive>
-> balena os configure <flasher-image> --fleet <fleet-slug> --version <os-version>
+  unzip <flasher-image-archive>
+  balena os configure <flasher-image> --fleet <fleet-slug> --version <os-version>
 ```
 
 ### Migrator
 The command below prepares the migration, and then reboots to execute it and launch balenaOS.
 ```
-> migrator [--non-interactive] <flasher-image>
+  migrator -i <value> [--noninteractive]
+
+FLAGS
+  -i, --image=<value>  (required) balenaOS flasher image path name
+  --noninteractive     no user input; use defaults
 ```
 Since the migrator executes a destructive operation, it first prompts you to confirm continuing. Use the `--non-interactive` option to avoid the prompt and immediately begin the migration.
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "migrator",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@oclif/core": "^2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,19 +7,22 @@ export default class Migrator extends Command {
 	static description = 'Migrate this device to balenaOS';
 
 	static examples = [
-		'> migrate \\Users\\Bob\\balenaos.img',
+		'migrator \\Users\\John\\balena-flasher.img',
 	];
 
-	static args = {
-		sourceImagePath: Args.string({description: 'balenaOS image path', required: true}),
-	};
-
 	static flags = {
+		image: Flags.string({
+			char: 'i',
+			required: true,
+			description: "balenaOS image path name",
+		}),
 		noninteractive: Flags.boolean({
 			aliases: [ 'non-interactive' ],
 			default: false,
+			description: "no user input; use defaults"
 		}),
 	};
+	static args = {};
 
 	async run(): Promise<void> {
 		const {args, flags} = await this.parse(Migrator)
@@ -39,7 +42,7 @@ export default class Migrator extends Command {
 				return;
 			}
 		}
-		migrator.migrate(args.sourceImagePath, winPartition, deviceName, efiLabel)
+		migrator.migrate(flags.image, winPartition, deviceName, efiLabel)
 			.then(console.log)
 			.catch(console.log);
 	}

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,8 +16,8 @@ export default class Migrator extends Command {
 			required: true,
 			description: "balenaOS image path name",
 		}),
-		noninteractive: Flags.boolean({
-			aliases: [ 'non-interactive' ],
+		'non-interactive': Flags.boolean({
+			char: 'y',
 			default: false,
 			description: "no user input; use defaults"
 		}),
@@ -30,7 +30,7 @@ export default class Migrator extends Command {
 		const deviceName = "\\\\.\\PhysicalDrive0";
 		const efiLabel = "M";
 
-		if (!flags.noninteractive) {
+		if (!flags['non-interactive']) {
 			console.log("Warning! This tool will overwrite the operating system and all data on this computer.");
 			let responses: any = await inquirer.prompt([{
 				name: 'continue',


### PR DESCRIPTION
Use a flag, `-i / --image`, to specify the flasher image file, rather than a positional argument. As a single command tool, `migrator` may accumulate more options for how to retrieve an image file. Use of an explicit flag allows us more flexibility for the future.

Also, add a `-y` shortcut for the non-interactive option, and ensure the option includes a dash between *non* and *interactive*.