### PR TITLE
Fail build if drivelist native module missing

### DIFF
--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -48,6 +48,10 @@ runs:
         # workaround exclusion of drivelist compiled module
         rm node_modules\pkg\dictionary\drivelist.js
         npm run build
+        if (!(Test-Path "node_modules\drivelist\build\Release\drivelist.node")) {
+          Write-Error "drivelist.node not found"
+          Exit 1
+        }
         npm run pkg
 
         set version "v$(yq e '.[0].version' .versionbot\CHANGELOG.yml)"

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "migrator",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@oclif/core": "^2",


### PR DESCRIPTION
Workaround to recognize Issue #7. Must retry the build.

Fixes #7