### PR TITLE
Add option to analyze only

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,12 @@ Download the most recent migrator executable from the Releases [page](https://gi
 
 You must run the command below as Administrator on Windows.
 ```
-  > migrator -i balena-flasher.img [-y]
+  > migrator -i balena-flasher.img [-y] [--analyze]
 
 FLAGS
   -i, --image=<value>    (required) balenaOS flasher image path name
   -y, --non-interactive  no user input; use defaults
+  --analyze              only analyze work to do; don't modify computer
 ```
 Since the migrator executes a destructive operation, it first prompts you to confirm. Use the `--non-interactive` option to avoid the prompt and begin the migration immediately.
 
@@ -54,10 +55,18 @@ You should see output like below on the CLI from a successful run of the migrato
 
 ```
 Migrate \\.\PhysicalDrive0 with image .\balena-flasher-dev.img
+
+Partitions on target:
+index 1, offset 1048576, type C12A7328-F81F-11D2-BA4B-00A0C93EC93B
+index 2, offset 105906176, type E3C9E316-0B5C-4DB8-817D-F92DF00215AE
+index 3, offset 122683392, type EBD0A0A2-B9E5-4433-87C0-68B6B72699C7
+index 4, offset 53129248768, type DE94BBA4-06D1-4D40-A16A-BFD50179D6AC
+
 Require 42991616 (41.00 MB) for boot partition
 Require 3977248768 (3793.00 MB) for rootA partition
 Found 1048576 (1.00 MB) not allocated on disk \\.\PhysicalDrive0
 Shrink partition C by 4020240384 (3834.00 MB)
+
 Create flasherBootPartition
 Created new partition for boot at offset 49109008384 with size 42991616
 Create flasherRootAPartition
@@ -65,6 +74,7 @@ Created new partition for data at offset 49152000000 with size 3977248768
 Copy flasherBootPartition from image to disk
 read: {"position":46137345,"bytes":41943041,"speed":655361128.9081677,"averageSpeed":655360015.625}
 write: {"position":41943041,"bytes":41943041,"speed":645276985.799303,"averageSpeed":645277553.8461539}
+Copy complete
 Copy flasherRootAPartition from image to disk
 read: {"position":281018368,"bytes":234881024,"speed":939524096,"averageSpeed":939524096}
 write: {"position":232783872,"bytes":232783872,"speed":927426052.665908,"averageSpeed":927425784.8605578}
@@ -73,6 +83,8 @@ write: {"position":375390208,"bytes":375390208,"speed":882800964.0826695,"averag
 ...
 read: {"position":4022337537,"bytes":3976200193,"speed":692391510.844067,"averageSpeed":700652016.3876652}
 write: {"position":3976200193,"bytes":3976200193,"speed":692235395.8367282,"averageSpeed":700281823.3532934}
+Copy complete
+
 Mount Windows boot partition and copy grub bootloader from image
 Cleared up mount M: for EFI
 Copying: /EFI/BOOT/BOOTX64.EFI 	~=>	 M:\EFI\Boot\BOOTX64.EFI

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -12,7 +12,7 @@
         "@oclif/core": "^2",
         "@oclif/plugin-help": "^5",
         "@oclif/plugin-plugins": "^2.3.2",
-        "etcher-sdk": "^8.5.x",
+        "etcher-sdk": "^8.6.x",
         "inquirer": "^8.2.5"
       },
       "bin": {
@@ -4773,9 +4773,9 @@
       }
     },
     "node_modules/etcher-sdk": {
-      "version": "8.5.3",
-      "resolved": "https://registry.npmjs.org/etcher-sdk/-/etcher-sdk-8.5.3.tgz",
-      "integrity": "sha512-EMaGQLrg/J0eSvWCkpsDQKD8/KW4lyc4iIp3yFv/B8T2t7txwO9ro3euY0bIRCUZRAjWePDpmBUggUnMiFfpGg==",
+      "version": "8.6.1",
+      "resolved": "https://registry.npmjs.org/etcher-sdk/-/etcher-sdk-8.6.1.tgz",
+      "integrity": "sha512-QgY4XHh24meJoqmkLDeqRe8gAYyobukP3xUizVOK/PZ6ZHDEUoCQ7EK3k0Puqc+mtR8lt+8Km+F6G+BtUfc+JQ==",
       "dependencies": {
         "@balena/node-beaglebone-usbboot": "^3.0.0",
         "@balena/udif": "^1.1.2",
@@ -15147,9 +15147,9 @@
       "dev": true
     },
     "etcher-sdk": {
-      "version": "8.5.3",
-      "resolved": "https://registry.npmjs.org/etcher-sdk/-/etcher-sdk-8.5.3.tgz",
-      "integrity": "sha512-EMaGQLrg/J0eSvWCkpsDQKD8/KW4lyc4iIp3yFv/B8T2t7txwO9ro3euY0bIRCUZRAjWePDpmBUggUnMiFfpGg==",
+      "version": "8.6.1",
+      "resolved": "https://registry.npmjs.org/etcher-sdk/-/etcher-sdk-8.6.1.tgz",
+      "integrity": "sha512-QgY4XHh24meJoqmkLDeqRe8gAYyobukP3xUizVOK/PZ6ZHDEUoCQ7EK3k0Puqc+mtR8lt+8Km+F6G+BtUfc+JQ==",
       "requires": {
         "@balena/node-beaglebone-usbboot": "^3.0.0",
         "@balena/udif": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@oclif/core": "^2",
     "@oclif/plugin-help": "^5",
     "@oclif/plugin-plugins": "^2.3.2",
-    "etcher-sdk": "^8.5.x",
+    "etcher-sdk": "^8.6.x",
     "inquirer": "^8.2.5"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,14 @@ export default class Migrator extends Command {
 			default: false,
 			description: "no user input; use defaults"
 		}),
+		'skip-tasks': Flags.string({
+			// See etcher-sdk migrate() function for list of valid tasks.
+			// Use some separator character between tasks, like a comma.
+			// Presently this option is for development/debugging only.
+			default: '',
+			hidden: true,
+			description: "don't perform these tasks"
+		}),
 	};
 	static args = {};
 
@@ -42,7 +50,10 @@ export default class Migrator extends Command {
 				return;
 			}
 		}
-		migrator.migrate(flags.image, winPartition, deviceName, efiLabel)
+
+		const options = { omitTasks: flags['skip-tasks'] }
+
+		migrator.migrate(flags.image, winPartition, deviceName, efiLabel, options)
 			.then(console.log)
 			.catch(console.log);
 	}


### PR DESCRIPTION
Adds an `--analyze` option to only analyze the work to be done; don't modify the computer.

Also adds a hidden `--last-task` option for the last migration task to perform. It's helpful for development and debugging but we're not ready to make it public yet. Tasks are performed in this order: _analyze, shrink partition, create/copy partitions, copy bootloader, reboot_.

Also adds a hidden `--skip-tasks` option, which provides more flexibility than `--last-task` by specifying which tasks to omit. This ability also may be helpful for troubleshooting. Both `--analyze` and `--last-task` ultimately specify a list of tasks to omit to the `migrate()` function API in Etcher SDK.