### PR TITLE
Failover and troubleshooting improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,12 @@ write: {"position":375390208,"bytes":375390208,"speed":882800964.0826695,"averag
 read: {"position":4022337537,"bytes":3976200193,"speed":692391510.844067,"averageSpeed":700652016.3876652}
 write: {"position":3976200193,"bytes":3976200193,"speed":692235395.8367282,"averageSpeed":700281823.3532934}
 Copy complete
+Copying: /EFI/BOOT/BOOTX64.EFI  ~=>      N:\EFI\Boot\BOOTX64.EFI
+Copying: /EFI/BOOT/GRUB.CFG     ~=>      N:\EFI\Boot\GRUB.CFG
+Copying: /EFI/BOOT/GRUBENV      ~=>      N:\EFI\Boot\GRUBENV
+Copying: /EFI/BOOT/bootx64.efi.secureboot       ~=>      N:\EFI\Boot\bootx64.efi.secureboot
+Copying: /EFI/BOOT/grub.cfg.sig         ~=>      N:\EFI\Boot\grub.cfg.sig
+Copying: /EFI/BOOT/grub_extraenv        ~=>      N:\EFI\Boot\grub_extraenv
 
 Write network configuration
 Wrote network configuration for quir29key

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ You must run the command below as Administrator on Windows.
 FLAGS
   -i, --image=<value>    (required) balenaOS flasher image path name
   --no-wifi              do not analyze WiFi network configurations
-
+  --verbose              display detailed output from operations
 ```
 
 You should see output like below on the CLI from the *analyze* command.
@@ -102,6 +102,7 @@ FLAGS
   -i, --image=<value>    (required) balenaOS flasher image path name
   -y, --non-interactive  no user input; use defaults
   --no-wifi              do not migrate WiFi network configurations
+  --verbose              display detailed output from operations
 ```
 Since the migrator executes a destructive operation, it first prompts you to confirm. Use the `--non-interactive` option to avoid the prompt and begin the migration immediately.
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -13,7 +13,7 @@
         "@oclif/plugin-help": "^5",
         "@oclif/plugin-plugins": "^2.3.2",
         "debug": "^3.1.0",
-        "etcher-sdk": "^8.7.x",
+        "etcher-sdk": "^8.7.2",
         "got": "^11.8.6",
         "inquirer": "^8.2.5",
         "ipaddr.js": "^2.1.0",
@@ -5047,9 +5047,9 @@
       }
     },
     "node_modules/etcher-sdk": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/etcher-sdk/-/etcher-sdk-8.7.0.tgz",
-      "integrity": "sha512-X/EUz1GYv3rVwe3o36anR0FXcpITtYeVfTDG0cwcD1+ZZmNDM/VcCh7KDYttboG6R/JUzY10EbDbVYT9Gcizuw==",
+      "version": "8.7.2",
+      "resolved": "https://registry.npmjs.org/etcher-sdk/-/etcher-sdk-8.7.2.tgz",
+      "integrity": "sha512-QYwz+8xMfA00U3ttJ0Y8rU1Q0rmed4nyEsFKWQ3edrCfL1FHJo/TBQrf59/+DFfy+myf4BD06X30r1Wb+A7XIg==",
       "dependencies": {
         "@balena/node-beaglebone-usbboot": "^3.0.0",
         "@balena/udif": "^1.1.2",
@@ -5067,7 +5067,7 @@
         "gzip-stream": "^2.0.0",
         "lzma-native": "^8.0.6",
         "mountutils": "^1.3.20",
-        "node-raspberrypi-usbboot": "1.0.6",
+        "node-raspberrypi-usbboot": "1.0.7",
         "outdent": "^0.8.0",
         "partitioninfo": "^6.0.2",
         "rwmutex": "^1.0.0",
@@ -7893,9 +7893,9 @@
       }
     },
     "node_modules/node-raspberrypi-usbboot": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/node-raspberrypi-usbboot/-/node-raspberrypi-usbboot-1.0.6.tgz",
-      "integrity": "sha512-t4c+bmXcvi3VK+YqfWz1k6Fv2XJAkUjwa217ANQCMvfdybpVV6rDD7VD4THXJRrK6zMxZWR0OgMZ/LK3gw/zVQ==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/node-raspberrypi-usbboot/-/node-raspberrypi-usbboot-1.0.7.tgz",
+      "integrity": "sha512-ebL2xC7GQSrbrbAdaj2P6rWCViDoh0ewsgu3gHrtOCNeioCZ6ESirUob1iXT/0DCCMqUDPZA0VV3+euCPRruJw==",
       "dependencies": {
         "debug": "^4.3.4",
         "usb": "^2.5.2"
@@ -15760,9 +15760,9 @@
       "dev": true
     },
     "etcher-sdk": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/etcher-sdk/-/etcher-sdk-8.7.0.tgz",
-      "integrity": "sha512-X/EUz1GYv3rVwe3o36anR0FXcpITtYeVfTDG0cwcD1+ZZmNDM/VcCh7KDYttboG6R/JUzY10EbDbVYT9Gcizuw==",
+      "version": "8.7.2",
+      "resolved": "https://registry.npmjs.org/etcher-sdk/-/etcher-sdk-8.7.2.tgz",
+      "integrity": "sha512-QYwz+8xMfA00U3ttJ0Y8rU1Q0rmed4nyEsFKWQ3edrCfL1FHJo/TBQrf59/+DFfy+myf4BD06X30r1Wb+A7XIg==",
       "requires": {
         "@balena/node-beaglebone-usbboot": "^3.0.0",
         "@balena/udif": "^1.1.2",
@@ -15780,7 +15780,7 @@
         "gzip-stream": "^2.0.0",
         "lzma-native": "^8.0.6",
         "mountutils": "^1.3.20",
-        "node-raspberrypi-usbboot": "1.0.6",
+        "node-raspberrypi-usbboot": "1.0.7",
         "outdent": "^0.8.0",
         "partitioninfo": "^6.0.2",
         "rwmutex": "^1.0.0",
@@ -17964,9 +17964,9 @@
       "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ=="
     },
     "node-raspberrypi-usbboot": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/node-raspberrypi-usbboot/-/node-raspberrypi-usbboot-1.0.6.tgz",
-      "integrity": "sha512-t4c+bmXcvi3VK+YqfWz1k6Fv2XJAkUjwa217ANQCMvfdybpVV6rDD7VD4THXJRrK6zMxZWR0OgMZ/LK3gw/zVQ==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/node-raspberrypi-usbboot/-/node-raspberrypi-usbboot-1.0.7.tgz",
+      "integrity": "sha512-ebL2xC7GQSrbrbAdaj2P6rWCViDoh0ewsgu3gHrtOCNeioCZ6ESirUob1iXT/0DCCMqUDPZA0VV3+euCPRruJw==",
       "requires": {
         "debug": "^4.3.4",
         "usb": "^2.5.2"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@oclif/plugin-help": "^5",
     "@oclif/plugin-plugins": "^2.3.2",
     "debug": "^3.1.0",
-    "etcher-sdk": "^8.7.x",
+    "etcher-sdk": "^8.7.2",
     "got": "^11.8.6",
     "inquirer": "^8.2.5",
     "ipaddr.js": "^2.1.0",

--- a/src/commands/analyze/index.ts
+++ b/src/commands/analyze/index.ts
@@ -4,6 +4,7 @@ import * as inquirer from 'inquirer';
 import { migrator } from 'etcher-sdk';
 import { Analyzer, ConnectionProfile } from '../../lib/networking-analyzer'
 import { MigratorCommand } from '../../lib/migrator-command'
+import * as debug from 'debug';
 
 export default class AnalyzerCommand extends MigratorCommand {
 	static description = 'Analyze migration of this device to balenaOS';
@@ -22,6 +23,10 @@ export default class AnalyzerCommand extends MigratorCommand {
 			default: false,
 			description: "do not analyze WiFi network configurations"
 		}),
+		'verbose': Flags.boolean({
+			default: false,
+			description: "display detailed output from operations"
+		})
 	};
 	static args = {};
 
@@ -30,6 +35,11 @@ export default class AnalyzerCommand extends MigratorCommand {
 		const winPartition = "C";
 		const deviceName = "\\\\.\\PhysicalDrive0";
 		const efiLabel = "M";
+
+		if (flags.verbose) {
+			// avoid essentially trace level logging on the copy step
+			debug.enable('*,-etcher:writer*,-rwmutex')
+		}
 
 		const skipTasks = 'shrink,copy,config,bootloader,reboot'
 		const options:migrator.MigrateOptions = { omitTasks: skipTasks, connectionProfiles: []}

--- a/src/commands/run/index.ts
+++ b/src/commands/run/index.ts
@@ -4,6 +4,7 @@ import * as inquirer from 'inquirer';
 import { migrator } from 'etcher-sdk';
 import { Analyzer, ConnectionProfile } from '../../lib/networking-analyzer'
 import { MigratorCommand } from '../../lib/migrator-command'
+import * as debug from 'debug';
 
 export default class RunCommand extends MigratorCommand {
 	static description = 'Run migration of this device to balenaOS';
@@ -45,6 +46,10 @@ export default class RunCommand extends MigratorCommand {
 			default: '',
 			hidden: true,
 			description: "don't perform these tasks"
+		}),
+		'verbose': Flags.boolean({
+			default: false,
+			description: "display detailed output from operations"
 		})
 	};
 	static args = {};
@@ -54,6 +59,11 @@ export default class RunCommand extends MigratorCommand {
 		const winPartition = "C";
 		const deviceName = "\\\\.\\PhysicalDrive0";
 		const efiLabel = "M";
+
+		if (flags.verbose) {
+			// avoid essentially trace level logging on the copy step
+			debug.enable('*,-etcher:writer*,-rwmutex')
+		}
 
 		if (!flags['non-interactive']) {
 			console.log("Warning! This tool will overwrite the operating system and all data on this computer.");


### PR DESCRIPTION
This update includes two improvements:

Updates to latest Etcher SDK v8.7.2, to allow a migration to failover to Windows if the computer boots into the flash-boot partition added by the migrator, rather than booting into the EFI system partition. The computer firmware decides the boot order among devices partitions, and this addition was driven by our experimentation on some new hardware/firmware.

Adds a `--verbose` option to both the `analyze` and `run` command targets. This option provides detailed output for the migration operation, especially network analysis. It can help with troubleshooting failures during migration.